### PR TITLE
Fix log folder

### DIFF
--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -30,7 +30,9 @@ import time
 
 from threading import Thread
 import logging
-TEMPDIR = 'log_files'
+TEMPDIR = '%s/log' % os.environ.get('HOME', '')
+if not os.path.exists(TEMPDIR):
+    os.mkdir(TEMPDIR)
 LOGFILE = "%s/migration_loggs.log" % TEMPDIR
 TIMEOUT_SECONDS = 30
 # Setup logging


### PR DESCRIPTION
First run of the script fails because the directory for the logs doesn't exist. Change to $HOME/log folder and ensure the folder exists before creating the logs.