### PR TITLE
Fix credential check in node drainer

### DIFF
--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -54,7 +54,7 @@ def getGredentials():
     :rtype: dict
     """
     cred = dict()
-    cred['auth_url'] = os.environ.get('OS_AUTH_URL').replace("v2.0", "v3")
+    cred['auth_url'] = os.environ.get('OS_AUTH_URL', '').replace("v2.0", "v3")
     cred['username'] = os.environ.get('OS_USERNAME')
     cred['password'] = os.environ.get('OS_PASSWORD')
     if 'OS_PROJECT_ID' in os.environ:


### PR DESCRIPTION
If no credentials were loaded, the .replace in L#57 failed without telling that the problem is that there was no OS_AUTH_URL. Having a default value, the replace works, and then the check in L#66 reports the missing credentials