### PR TITLE
Add support for multiple addresses in BCC

### DIFF
--- a/cloudmailer/cloudmailer-example.cfg
+++ b/cloudmailer/cloudmailer-example.cfg
@@ -21,8 +21,8 @@
 # (required) From who the email is sent from.
 # MAIL_FROM=my.email.example
 
-# (optional) If you want to send a BCC of all project emails. Defaults: False
-# MAIL_BCC=my.monitoring.email.example
+# (optional) If you want to send a BCC of all project emails. In case of multiple BCC emails, use a comma as a separator. Defaults: False
+# MAIL_BCC=my.monitoring.email.example,my.team.shared.email.example
 
 # (optional) How many nodes that will be scheduled downtime for at the same time
 # MAX_UPGRADE_AT_ONCE=10

--- a/cloudmailer/cloudmailer.py
+++ b/cloudmailer/cloudmailer.py
@@ -635,14 +635,18 @@ def sendMails(send_emails, subject, template, projects):
                 msg["Subject"] = subject
                 msg["To"] = email_address
 #                print(msg)
+                print ("Sending email to: %s" % email_address)
                 smtpconn.sendmail(MAIL_FROM, email_address, msg.as_string())
+                print ("Email to %s sent successfully" % email_address)
             if MAIL_BCC:
                 for single_mail_bcc in MAIL_BCC.split(","):
                     msg = MIMEText(message_bcc)
                     msg["Subject"] = subject + " - " + projects[project]["name"]
                     msg['To'] = single_mail_bcc
 #                    print(msg)
+                    print ("Sending BCC email to: %s" % single_mail_bcc)
                     smtpconn.sendmail(MAIL_FROM, single_mail_bcc, msg.as_string())
+                    print ("BCC email to %s sent successfully" % single_mail_bcc)
         elif notified_admin == False:
             print("Attention!!! Not sending emails right now. Please, check the created files and when you are sure execute this same command with '--I-am-sure-that-I-want-to-send-emails' parameter.")
             notified_admin = True

--- a/cloudmailer/cloudmailer.py
+++ b/cloudmailer/cloudmailer.py
@@ -630,6 +630,8 @@ def sendMails(send_emails, subject, template, projects):
                 askToContinue('Are you sure that you want to send the emails?', 'Yes I am sure')
                 ask_for_verification = False
             print ("Really sending emails to: %s" % ",".join(projects[project]["emails"]))
+            if MAIL_BCC:
+                print ("Really sending BCC emails to: %s" % MAIL_BCC)
             for email_address in projects[project]["emails"]:
                 msg = MIMEText(projmail_str)
                 msg["Subject"] = subject

--- a/cloudmailer/cloudmailer.py
+++ b/cloudmailer/cloudmailer.py
@@ -619,6 +619,8 @@ def sendMails(send_emails, subject, template, projects):
         emailcopy = open(file_name, "w")
         emailcopy.write("From: %s\n" % MAIL_FROM)
         emailcopy.write("To: %s\n" % emails_to)
+        if MAIL_BCC:
+            emailcopy.write("Bcc: %s\n" % MAIL_BCC)
         emailcopy.write("Subject: %s\n" % subject)
         emailcopy.write(projmail_str)
         emailcopy.close()
@@ -635,11 +637,12 @@ def sendMails(send_emails, subject, template, projects):
 #                print(msg)
                 smtpconn.sendmail(MAIL_FROM, email_address, msg.as_string())
             if MAIL_BCC:
-                msg = MIMEText(message_bcc)
-                msg["Subject"] = subject + " - " + projects[project]["name"]
-                msg['To'] = MAIL_BCC
-#                print(msg)
-                smtpconn.sendmail(MAIL_FROM, MAIL_BCC.split(","), msg.as_string())
+                for single_mail_bcc in MAIL_BCC.split(","):
+                    msg = MIMEText(message_bcc)
+                    msg["Subject"] = subject + " - " + projects[project]["name"]
+                    msg['To'] = single_mail_bcc
+#                    print(msg)
+                    smtpconn.sendmail(MAIL_FROM, single_mail_bcc, msg.as_string())
         elif notified_admin == False:
             print("Attention!!! Not sending emails right now. Please, check the created files and when you are sure execute this same command with '--I-am-sure-that-I-want-to-send-emails' parameter.")
             notified_admin = True

--- a/cloudmailer/cloudmailer.py
+++ b/cloudmailer/cloudmailer.py
@@ -639,7 +639,7 @@ def sendMails(send_emails, subject, template, projects):
                 msg["Subject"] = subject + " - " + projects[project]["name"]
                 msg['To'] = MAIL_BCC
 #                print(msg)
-                smtpconn.sendmail(MAIL_FROM, MAIL_BCC, msg.as_string())
+                smtpconn.sendmail(MAIL_FROM, MAIL_BCC.split(","), msg.as_string())
         elif notified_admin == False:
             print("Attention!!! Not sending emails right now. Please, check the created files and when you are sure execute this same command with '--I-am-sure-that-I-want-to-send-emails' parameter.")
             notified_admin = True


### PR DESCRIPTION
The proposed change allows the definition of multiple BCC addresses by splitting the MAIL_BCC string using comma as the separator and feeding a list of the addresses obtained to the smtplib object.