### PR TITLE
node-drainer to handle paused and suspended instances

### DIFF
--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -305,9 +305,11 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
            and getattr(instance, 'OS-EXT-STS:task_state') == None
            and stop_paused_instances):
         nova.servers.unpause(instance)
-        wait_for_instance_status(nova, instance, 'ACTIVE', 63)
+        # Wait time for instance to unpause 60s (default timeout) + 30s
+        wait_for_instance_status(nova, instance, 'ACTIVE', 90)
         nova.servers.stop(instance)
-        wait_for_instance_status(nova, instance, 'SHUTOFF', 303)
+        # Wait time for instance to shutoff 300s (timeout we have before force shutoff) + 30s
+        wait_for_instance_status(nova, instance, 'SHUTOFF', 330)
         success = coldMigrateInstance(instance)
     elif ( instance.status == 'SUSPENDED'
            and getattr(instance, 'OS-EXT-STS:power_state') == 4
@@ -315,9 +317,11 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
            and getattr(instance, 'OS-EXT-STS:task_state') == None
            and stop_suspended_instances):
         nova.servers.resume(instance)
-        wait_for_instance_status(nova, instance, 'ACTIVE', 63)
+        # Wait time for instance to shutoff 300s (timeout we have before force shutoff) + 30s
+        wait_for_instance_status(nova, instance, 'ACTIVE', 90)
         nova.servers.stop(instance)
-        wait_for_instance_status(nova, instance, 'SHUTOFF', 303)
+        # Wait time for instance to shutoff 300s (timeout we have before force shutoff) + 30s
+        wait_for_instance_status(nova, instance, 'SHUTOFF', 330)
         success = coldMigrateInstance(instance)
     else:
         log_instance_state(instance)

--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -348,12 +348,12 @@ def wait_for_instance_status(nova, instance, desired_status, timeout=30, interva
             return False
         time.sleep(interval)
 
-def drainHypervisor(node, flavors, max_instances_to_migrate, allow_block_migration, allow_live_block_migration):
+def drainHypervisor(node, flavors, max_instances_to_migrate, allow_block_migration, allow_live_block_migration, stop_paused_instances, stop_suspended_instances):
     instances = getInstances(node, flavors)
     # Create a list of instace uuid from a list of instance objects
     list_of_instance_uuids = list(map(lambda x: x.id, instances))
     pprint (allow_live_block_migration)
-    migrateInstances(instances, flavors, max_instances_to_migrate, allow_block_migration, allow_live_block_migration)
+    migrateInstances(instances, flavors, max_instances_to_migrate, allow_block_migration, allow_live_block_migration, stop_paused_instances, stop_suspended_instances)
     instances = getInstances(node, flavors)
     list_of_instance_uuids = list(map(lambda x: x.id, instances))
     log_and_print("Instances still on " + node.hypervisor_hostname + ": " + str(list_of_instance_uuids))
@@ -439,7 +439,7 @@ def main(argv=None):
        flavor_ids = getFlavorIDs(flavors)
        # This script apperently only drain one node at the time. Note that this might
        # be annoying with max_instances_to_migrate
-       drainHypervisor(nodes[0], flavor_ids, max_instances_to_migrate, allow_block_migration, allow_live_block_migration)
+       drainHypervisor(nodes[0], flavor_ids, max_instances_to_migrate, allow_block_migration, allow_live_block_migration, stop_paused_instances, stop_suspended_instances)
 
 print(timeStr() + " Script started, logs will be stored: " + LOGFILE )
 if __name__ == "__main__":

--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -307,7 +307,7 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
         nova.servers.unpause(instance)
         wait_for_instance_status(nova, instance, 'ACTIVE')
         nova.servers.stop(instance)
-        wait_for_instance_status(nova, instance, 'SHUTOFF')
+        wait_for_instance_status(nova, instance, 'SHUTOFF', 330)
         success = coldMigrateInstance(instance)
     elif ( instance.status == 'SUSPENDED'
            and getattr(instance, 'OS-EXT-STS:power_state') == 4
@@ -317,7 +317,7 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
         nova.servers.resume(instance)
         wait_for_instance_status(nova, instance, 'ACTIVE')
         nova.servers.stop(instance)
-        wait_for_instance_status(nova, instance, 'SHUTOFF')
+        wait_for_instance_status(nova, instance, 'SHUTOFF', 330)
         success = coldMigrateInstance(instance)
     else:
         log_instance_state(instance)
@@ -340,10 +340,8 @@ def wait_for_instance_status(nova, instance, desired_status, timeout=30, interva
             return True
         elif instance.status == 'ERROR':
             failure(' ERROR ' + instance.id + ' Instance status: ' + instance.status, 1)
-            return False
         elif time.time() - start_time > timeout:
             failure(' ERROR ' + instance.id + ' Timed out after ' + str(timeout) + ' seconds waiting for the instance to reach ' + desired_status + '. Current status: ' + instance.status, 1)
-            return False
         time.sleep(interval)
 
 def drainHypervisor(node, flavors, max_instances_to_migrate, allow_block_migration, allow_live_block_migration, stop_paused_instances, stop_suspended_instances):

--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -305,9 +305,9 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
            and getattr(instance, 'OS-EXT-STS:task_state') == None
            and stop_paused_instances):
         nova.servers.unpause(instance)
-        wait_for_instance_status(nova, instance, 'ACTIVE')
+        wait_for_instance_status(nova, instance, 'ACTIVE', 63)
         nova.servers.stop(instance)
-        wait_for_instance_status(nova, instance, 'SHUTOFF', 330)
+        wait_for_instance_status(nova, instance, 'SHUTOFF', 303)
         success = coldMigrateInstance(instance)
     elif ( instance.status == 'SUSPENDED'
            and getattr(instance, 'OS-EXT-STS:power_state') == 4
@@ -315,9 +315,9 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
            and getattr(instance, 'OS-EXT-STS:task_state') == None
            and stop_suspended_instances):
         nova.servers.resume(instance)
-        wait_for_instance_status(nova, instance, 'ACTIVE')
+        wait_for_instance_status(nova, instance, 'ACTIVE', 63)
         nova.servers.stop(instance)
-        wait_for_instance_status(nova, instance, 'SHUTOFF', 330)
+        wait_for_instance_status(nova, instance, 'SHUTOFF', 303)
         success = coldMigrateInstance(instance)
     else:
         log_instance_state(instance)
@@ -328,7 +328,7 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
 
     return success
 
-def wait_for_instance_status(nova, instance, desired_status, timeout=30, interval=3):
+def wait_for_instance_status(nova, instance, desired_status, timeout=60, interval=3):
     """Wait for the instance to reach the desired status."""
     start_time = time.time()
     instance = nova.servers.get(instance.id)

--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -95,11 +95,9 @@ python """ + argv[0] + """ -y host1 -y host2 -y host3""")
                        default=False, help='Allow live block migration.\nWarning this can be quite'
                        + 'dangerous', action='store_true')
    parser.add_argument('--stop-paused-instances', dest='stop_paused_instances',
-                       default=False, help='Stop paused instances.\nWarning this can be quite'
-                       + 'dangerous', action='store_true')
+                       default=False, help='Stop paused instances.', action='store_true')
    parser.add_argument('--stop-suspended-instances', dest='stop_suspended_instances',
-                       default=False, help='Stop suspended instances.\nWarning this can be quite'
-                       + 'dangerous', action='store_true')
+                       default=False, help='Stop suspended instances.', action='store_true')
    parser.add_argument('-i', '--instance', dest='instances', type=str,
                        help='Instance to migrate', action='append', required=False)
 
@@ -341,10 +339,10 @@ def wait_for_instance_status(nova, instance, desired_status, timeout=30, interva
             log_and_print(instance.id + ' Instance is now ' + desired_status + '.')
             return True
         elif instance.status == 'ERROR':
-            failure(' ERROR ' + instance.id + ' Instance status: ' + instance.status)
+            failure(' ERROR ' + instance.id + ' Instance status: ' + instance.status, 1)
             return False
         elif time.time() - start_time > timeout:
-            failure(' ERROR ' + instance.id + ' Timed out after ' + str(timeout) + ' seconds waiting for the instance to reach ' + desired_status + '. Current status: ' + instance.status)
+            failure(' ERROR ' + instance.id + ' Timed out after ' + str(timeout) + ' seconds waiting for the instance to reach ' + desired_status + '. Current status: ' + instance.status, 1)
             return False
         time.sleep(interval)
 

--- a/node-drainer/node-drainer.py
+++ b/node-drainer/node-drainer.py
@@ -317,7 +317,7 @@ def migrateInstance(instance, allow_live_block_migration, stop_paused_instances,
            and getattr(instance, 'OS-EXT-STS:task_state') == None
            and stop_suspended_instances):
         nova.servers.resume(instance)
-        # Wait time for instance to shutoff 300s (timeout we have before force shutoff) + 30s
+        # Wait time for instance to resume 60s (default timeout) + 30s
         wait_for_instance_status(nova, instance, 'ACTIVE', 90)
         nova.servers.stop(instance)
         # Wait time for instance to shutoff 300s (timeout we have before force shutoff) + 30s


### PR DESCRIPTION
node-drainer update to allow shutting down paused and suspended instances before migration.